### PR TITLE
Add multi line support to color text generator

### DIFF
--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -131,6 +131,17 @@
         })
     }
 
+    function autoSizeTextArea(event) {
+        const target = event.target as HTMLTextAreaElement;
+        if (!target.value.includes("\n")) {
+            // resets element back to the minimum size defined in the class
+            target.style.height = "35px";
+        } else {
+            target.style.height = "auto";
+            target.style.height = target.scrollHeight + "px";
+        }
+    }
+
     let color = "#FFFFFF";
 </script>
 
@@ -182,7 +193,7 @@
         </div>
 
         <div class="flex gap-3">
-            <textarea id="textinput" bind:value={text} class="inline-block text-sm text-gray-400 font-mono rounded-md p-2 bg-[#141517] mt-8 h-[35px] w-[100%] max-w-[100%] "></textarea>
+            <textarea id="textinput" on:input={autoSizeTextArea} bind:value={text} class="inline-block text-sm text-gray-400 font-mono rounded-md p-2 bg-[#141517] mt-8 h-[35px] w-[100%] max-w-[100%] overflow-y-hidden"></textarea>
             <button class="w-fit text-sm px-2 py-1.5 button h-fit inline-block mt-8" on:click={copyValue}>Copy</button>
         </div>
     </div>

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -182,7 +182,7 @@
         </div>
 
         <div class="flex gap-3">
-            <input id="textinput" bind:value={text} class="inline-block text-sm text-gray-400 font-mono rounded-md p-2 bg-[#141517] mt-8 h-[35px] w-[100%] max-w-[100%] ">
+            <textarea id="textinput" bind:value={text} class="inline-block text-sm text-gray-400 font-mono rounded-md p-2 bg-[#141517] mt-8 h-[35px] w-[100%] max-w-[100%] "></textarea>
             <button class="w-fit text-sm px-2 py-1.5 button h-fit inline-block mt-8" on:click={copyValue}>Copy</button>
         </div>
     </div>

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -132,13 +132,13 @@
     }
 
     function autoSizeTextArea(event) {
-        const target = event.target as HTMLTextAreaElement;
+        const target = event.target;
         if (!target.value.includes("\n")) {
-            // resets element back to the minimum size defined in the class
-            target.style.height = "35px";
+            // removes all inline styles from this element
+            target.setAttribute("style", '')
         } else {
-            target.style.height = "auto";
-            target.style.height = target.scrollHeight + "px";
+            target.setAttribute("style", "height:auto")
+            target.setAttribute("style", "height:" + target.scrollHeight + "px")
         }
     }
 


### PR DESCRIPTION
As the title says. The text area height gets automatically resized based on the content, and whenever the lines becomes too large for a particular preview, naturally it just excludes it.

Tested:
- Previews: all (Text, Sign, Book, Chat, MOTD, Name, Lore, Kick)
- Browser: Firefox and Edge
- Resolutions (via Firefox's Responsive Design Mode): Desktop (1440x2560) and Mobile (476x480).
- Functionalities:
  - The insert color (`insertTextAtCursor`) functionality seems to be working.
  - The copy button is copying the multi-line texts correctly.
  
Test input:
```
&1First Line
&2Second Line
&3Third Line
&4Fourth Line
&5Fifth Line
```
  
Demonstration:
![image](https://github.com/flytegg/mc-utils/assets/47629321/9211b25d-9c31-466a-90c6-af13624a6cdd)