### PR TITLE
Fix color reset inconsistency

### DIFF
--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -70,35 +70,47 @@
         previewText = applyMinecraftFormatting(text);
     });
 
+    function getResetStyleOptions() {
+        // 'font-weight: normal' removes the bold effect
+        // 'display: inline-block' removes the decorations (which are: underline, line-through)
+        //    - 'text-decoration: none' won't work here as they're unable to remove inherited decorations
+        // 'font-style: normal' removes the italic effect
+        return `font-weight: normal; display: inline-block; font-style: normal;`
+    }
+
     function applyMinecraftFormatting(text) {
+        function getColorStyle(color) {
+            return `<span style="color: #${color}; ${getResetStyleOptions()}">`
+        }
+
         // Color codes
-        text = text.replace(/&0/g, '<span style="color: #000000">'); // Black
-        text = text.replace(/&1/g, '<span style="color: #0000AA">'); // Dark Blue
-        text = text.replace(/&2/g, '<span style="color: #00AA00">'); // Dark Green
-        text = text.replace(/&3/g, '<span style="color: #00AAAA">'); // Dark Aqua
-        text = text.replace(/&4/g, '<span style="color: #AA0000">'); // Dark Red
-        text = text.replace(/&5/g, '<span style="color: #AA00AA">'); // Dark Purple
-        text = text.replace(/&6/g, '<span style="color: #FFAA00">'); // Gold
-        text = text.replace(/&7/g, '<span style="color: #AAAAAA">'); // Gray
-        text = text.replace(/&8/g, '<span style="color: #555555">'); // Dark Gray
-        text = text.replace(/&9/g, '<span style="color: #5555FF">'); // Blue
-        text = text.replace(/&a/g, '<span style="color: #55FF55">'); // Green
-        text = text.replace(/&b/g, '<span style="color: #55FFFF">'); // Aqua
-        text = text.replace(/&c/g, '<span style="color: #FF5555">'); // Red
-        text = text.replace(/&d/g, '<span style="color: #FF55FF">'); // Light Purple
-        text = text.replace(/&e/g, '<span style="color: #FFFF55">'); // Yellow
-        text = text.replace(/&f/g, '<span style="color: #FFFFFF">'); // White
+        text = text.replace(/&0/g, () => getColorStyle('000000')); // Black
+        text = text.replace(/&1/g, () => getColorStyle('0000AA')); // Dark Blue
+        text = text.replace(/&2/g, () => getColorStyle('00AA00')); // Dark Green
+        text = text.replace(/&3/g, () => getColorStyle('00AAAA')); // Dark Aqua
+        text = text.replace(/&4/g, () => getColorStyle('AA0000')); // Dark Red
+        text = text.replace(/&5/g, () => getColorStyle('AA00AA')); // Dark Purple
+        text = text.replace(/&6/g, () => getColorStyle('FFAA00')); // Gold
+        text = text.replace(/&7/g, () => getColorStyle('AAAAAA')); // Gray
+        text = text.replace(/&8/g, () => getColorStyle('555555')); // Dark Gray
+        text = text.replace(/&9/g, () => getColorStyle('5555FF')); // Blue
+        text = text.replace(/&a/g, () => getColorStyle('55FF55')); // Green
+        text = text.replace(/&b/g, () => getColorStyle('55FFFF')); // Aqua
+        text = text.replace(/&c/g, () => getColorStyle('FF5555')); // Red
+        text = text.replace(/&d/g, () => getColorStyle('FF55FF')); // Light Purple
+        text = text.replace(/&e/g, () => getColorStyle('FFFF55')); // Yellow
+        text = text.replace(/&f/g, () => getColorStyle('FFFFFF')); // White
 
         // Hex code
         const regex = /&#([A-Fa-f0-9]{6})/g;
-        text = text.replace(regex, (match, color) => `<span style="color: #${color}">`);
+        text = text.replace(regex, (match, color) => getColorStyle(color));
 
         // Formatting codes
-        text = text.replace(/&k/g, '<span style="font-weight: bold">'); // Obfuscated
-        text = text.replace(/&l/g, '<span style="font-weight: bold">'); // Bold
-        text = text.replace(/&m/g, '<span style="text-decoration: line-through">'); // Strikethrough
-        text = text.replace(/&n/g, '<span style="text-decoration: underline">'); // Underline
-        text = text.replace(/&o/g, '<span style="font-style: italic">'); // Italic
+        text = text.replace(/&k/g, '<span style="font-weight: bold;">'); // Obfuscated
+        text = text.replace(/&l/g, '<span style="font-weight: bold;">'); // Bold
+        text = text.replace(/&m/g, '<span style="text-decoration: line-through;">'); // Strikethrough
+        text = text.replace(/&n/g, '<span style="text-decoration: underline;">'); // Underline
+        text = text.replace(/&o/g, '<span style="font-style: italic;">'); // Italic
         text = text.replace(/&r/g, getResetStyle()); // Reset
 
         document.getElementById("textinput").focus();
@@ -108,13 +120,13 @@
 
     function getResetStyle() {
         if (activeTab === 0 || activeTab === 3 || activeTab === 5 || activeTab === 6 || activeTab === 7) {
-            return '<span style="color: #FFFFFF">';
+            return `<span style="color: #FFFFFF; ${getResetStyleOptions()}">`;
         } else if (activeTab === 1 || activeTab === 2) {
-            return '<span style="color: #000000">';
+            return `<span style="color: #000000; ${getResetStyleOptions()}">`;
         } else if (activeTab === 4) {
-            return '<span style="color: #AAAAAA">';
+            return `<span style="color: #AAAAAA; ${getResetStyleOptions()}">`;
         } else {
-            return '<span>'; // Default - No color
+            return `<span style="${getResetStyleOptions()}">`; // Default - No color
         }
     }
 


### PR DESCRIPTION
This pull request is aimed to address color reset inconsistency in the color text generator utility. This should hopefully solve the #175 issue. 

For reference, I used Esssentials Chat in-game here to differentiate between incorrect and correct behavior. I also made sure to apply the fix to every preview. If I missed something or there are any improvements that I could make, feel free to let me know!

Fixed the following inconsistencies:
- `&r` (reset) and `&0-9`/`&a-f` (any and all colors) not removing the bold/italic effects and inherited underline/line-through decorations. From what I understand, the only thing `&r` (reset) did was reset the color and `&0-9` & `&a-f` only changed the color.

Test cases:
- **Bold**: &c&lhi &etest
  - Previous: 
    - ![Screen Shot 2024-04-01 at 10 53 15](https://github.com/flytegg/mc-utils/assets/47629321/11963968-2da5-4a02-a328-63f584321e4a)
  - Now: 
    - ![Screen Shot 2024-04-01 at 10 53 46](https://github.com/flytegg/mc-utils/assets/47629321/1a7042e7-f81b-49dc-b485-ec3b3a03cfc0)
  - In game:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/3925baf7-83ca-4044-b2b6-ba647527f066)

- **Italic**: &e&ohi &r&etest
  - Previous:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/c5876c55-99b5-4bd0-88a3-1dbb7a94e2cb)
  - Now:
    - ![Screen Shot 2024-04-01 at 11 16 53](https://github.com/flytegg/mc-utils/assets/47629321/8eb15113-ffbe-47ee-842e-fe85b0885c16)
  - In game: ![image](https://github.com/flytegg/mc-utils/assets/47629321/d7663dc2-0007-4063-9e73-f104e98937f9)



- **Underline**: &c&nhi &etest
  - Previous:
    - ![Screen Shot 2024-04-01 at 11 04 16](https://github.com/flytegg/mc-utils/assets/47629321/d69f0820-eccb-4bd7-8f7b-e1c32b0106df)
  - Now:
    - ![Screen Shot 2024-04-01 at 11 04 23](https://github.com/flytegg/mc-utils/assets/47629321/b2460eba-6f40-4408-91f1-b1db7a8f5f38)
  - In game:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/6990deeb-3220-494f-8c52-c452edc1c610)

- **Line-through**: &c&mhi &etest
  - Previous:
    - ![Screen Shot 2024-04-01 at 11 06 05](https://github.com/flytegg/mc-utils/assets/47629321/74cd0096-1c18-4293-a412-131444ef289b)
  - Now:
    - ![Screen Shot 2024-04-01 at 11 06 15](https://github.com/flytegg/mc-utils/assets/47629321/0a81b0fc-4610-4638-8fc4-a14c231c4e36)
  - In game:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/a580f877-7a82-4af5-bf51-db43928910ba)
