### PR TITLE
Apply MC color formatting algorithmically

### DIFF
--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -144,21 +144,44 @@
             decorationColorType = ""
         }
 
+        function isGradient(text) {
+            const regex = /&#([A-Fa-f0-9]{6})/g;
+            return regex.test(text);
+        }
+
+        function getGradientColor(text) {
+            const regex = /&#([A-Fa-f0-9]{6})/g;
+
+            let gradientColor = ""
+            text.replace(regex, (match, color) => gradientColor = color);
+            return gradientColor
+        }
+
         for (let i = 0; i < text.length; i++) {
             const c = text[i]
 
             const nextC = text.charAt(i + 1)
             let hasFormatSign = c === "&";
 
-            if (hasFormatSign && isValidColorChar(nextC)) {
+            let isGradient = false
+            let hexSlice = text.slice(i, i + 8);
+            if (hasFormatSign && (isValidColorChar(nextC) || (isGradient = isGradient(hexSlice)))) {
                 // skip to next char
-                i += 1
+                if (isGradient) {
+                    i += 7
+                } else {
+                    i += 1
+                }
 
                 // release previous color/decoration
                 releaseTextOfColorMode();
                 releaseTextOfDecorationMode();
 
-                colorType = getColorStyleFromChar(nextC)
+                if (isGradient) {
+                    colorType = getGradientColor(hexSlice)
+                } else {
+                    colorType = getColorStyleFromChar(nextC)
+                }
                 coloringMode = true
                 continue
             } else if (hasFormatSign && isValidDecorationChar(nextC)) {

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -70,30 +70,18 @@
         previewText = applyMinecraftFormatting(text);
     });
 
-    function getResetStyleOptions() {
-        // 'font-weight: normal' removes the bold effect
-        // 'display: inline-block' removes the decorations (which are: underline, line-through)
-        //    - 'text-decoration: none' won't work here as they're unable to remove inherited decorations
-        // 'font-style: normal' removes the italic effect
-        return `font-weight: normal; display: inline-block; font-style: normal;`
-    }
-
     function applyMinecraftFormatting(text) {
         let htmlText = ""
 
-        function getColorStyle(color) {
-            return `<span style="color: #${color}; ${getResetStyleOptions()}">`
-        }
-
-        function isValidColorChar(c) {
-            let result = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-            console.log(`isValidColorChar(${c}): ${result}`)
+        function isValidColorChar(char) {
+            let result = (char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F');
+            console.log(`isValidColorChar(${char}): ${result}`)
             return result;
         }
 
-        function isValidDecorationChar(c) {
-            let result = (c >= 'k' && c <= 'o') || (c >= 'K' && c <= 'O');
-            console.log(`isValidDecorationChar(${c}): ${result}`)
+        function isValidDecorationChar(char) {
+            let result = (char >= 'k' && char <= 'o') || (char >= 'K' && char <= 'O');
+            console.log(`isValidDecorationChar(${char}): ${result}`)
             return result;
         }
 

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -74,15 +74,11 @@
         let htmlText = ""
 
         function isValidColorChar(char) {
-            let result = (char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F');
-            console.log(`isValidColorChar(${char}): ${result}`)
-            return result;
+            return (char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F');
         }
 
         function isValidDecorationChar(char) {
-            let result = (char >= 'k' && char <= 'o') || (char >= 'K' && char <= 'O');
-            console.log(`isValidDecorationChar(${char}): ${result}`)
-            return result;
+            return (char >= 'k' && char <= 'o') || (char >= 'K' && char <= 'O');
         }
 
         function getColorStyleFromChar(char) {
@@ -129,19 +125,16 @@
 
         function releaseTextOfColorMode() {
             if (!coloringMode) return
-            console.log('writing color')
             htmlText += `<span style="color: #${colorType};">${coloredText}</span>`
 
             // reset
             coloringMode = false
             coloredText = ""
             colorType = ""
-            console.log('coloring = false')
         }
 
         function releaseTextOfDecorationMode() {
             if (!decorationMode) return
-            console.log('writing decoration')
             htmlText += `<span style="color: #${decorationColorType}; ${decorationStyles}">${decorationText}</span>`
 
             // reset
@@ -149,12 +142,10 @@
             decorationText = ""
             decorationStyles = ""
             decorationColorType = ""
-            console.log('decoration = false')
         }
 
         for (let i = 0; i < text.length; i++) {
             const c = text[i]
-            console.log(`char=${c} at index ${i}`)
 
             const nextC = text.charAt(i + 1)
             let hasFormatSign = c === "&";
@@ -169,7 +160,6 @@
 
                 colorType = getColorStyleFromChar(nextC)
                 coloringMode = true
-                console.log('coloring = true')
                 continue
             } else if (hasFormatSign && isValidDecorationChar(nextC)) {
                 // skip to next char
@@ -186,14 +176,12 @@
 
                 // release and inherit current colors
                 if (coloringMode) {
-                    console.log('inheriting colored text to append decoration styles')
                     decorationColorType = colorType
                     releaseTextOfColorMode()
                 }
 
                 decorationStyles += getDecorationStyleFromChar(nextC)
                 decorationMode = true
-                console.log('decoration = true')
                 continue
             } else if (hasFormatSign && nextC === "r") {
                 // skip to next char
@@ -201,7 +189,6 @@
 
                 releaseTextOfColorMode()
                 releaseTextOfDecorationMode()
-                console.log('reset')
                 continue
             }
 

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -79,54 +79,169 @@
     }
 
     function applyMinecraftFormatting(text) {
+        let htmlText = ""
+
         function getColorStyle(color) {
             return `<span style="color: #${color}; ${getResetStyleOptions()}">`
         }
 
-        // Color codes
-        text = text.replace(/&0/g, () => getColorStyle('000000')); // Black
-        text = text.replace(/&1/g, () => getColorStyle('0000AA')); // Dark Blue
-        text = text.replace(/&2/g, () => getColorStyle('00AA00')); // Dark Green
-        text = text.replace(/&3/g, () => getColorStyle('00AAAA')); // Dark Aqua
-        text = text.replace(/&4/g, () => getColorStyle('AA0000')); // Dark Red
-        text = text.replace(/&5/g, () => getColorStyle('AA00AA')); // Dark Purple
-        text = text.replace(/&6/g, () => getColorStyle('FFAA00')); // Gold
-        text = text.replace(/&7/g, () => getColorStyle('AAAAAA')); // Gray
-        text = text.replace(/&8/g, () => getColorStyle('555555')); // Dark Gray
-        text = text.replace(/&9/g, () => getColorStyle('5555FF')); // Blue
-        text = text.replace(/&a/g, () => getColorStyle('55FF55')); // Green
-        text = text.replace(/&b/g, () => getColorStyle('55FFFF')); // Aqua
-        text = text.replace(/&c/g, () => getColorStyle('FF5555')); // Red
-        text = text.replace(/&d/g, () => getColorStyle('FF55FF')); // Light Purple
-        text = text.replace(/&e/g, () => getColorStyle('FFFF55')); // Yellow
-        text = text.replace(/&f/g, () => getColorStyle('FFFFFF')); // White
+        function isValidColorChar(c) {
+            let result = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            console.log(`isValidColorChar(${c}): ${result}`)
+            return result;
+        }
 
-        // Hex code
-        const regex = /&#([A-Fa-f0-9]{6})/g;
-        text = text.replace(regex, (match, color) => getColorStyle(color));
+        function isValidDecorationChar(c) {
+            let result = (c >= 'k' && c <= 'o') || (c >= 'K' && c <= 'O');
+            console.log(`isValidDecorationChar(${c}): ${result}`)
+            return result;
+        }
 
-        // Formatting codes
-        text = text.replace(/&k/g, '<span style="font-weight: bold;">'); // Obfuscated
-        text = text.replace(/&l/g, '<span style="font-weight: bold;">'); // Bold
-        text = text.replace(/&m/g, '<span style="text-decoration: line-through;">'); // Strikethrough
-        text = text.replace(/&n/g, '<span style="text-decoration: underline;">'); // Underline
-        text = text.replace(/&o/g, '<span style="font-style: italic;">'); // Italic
-        text = text.replace(/&r/g, getResetStyle()); // Reset
+        function getColorStyleFromChar(char) {
+            const colorMap = {
+                "0": "000000",  // Black
+                "1": "0000AA",  // Dark Blue
+                "2": "00AA00",  // Dark Green
+                "3": "00AAAA",  // Dark Aqua
+                "4": "AA0000",  // Dark Red
+                "5": "AA00AA",  // Dark Purple
+                "6": "FFAA00",  // Gold
+                "7": "AAAAAA",  // Gray
+                "8": "555555",  // Dark Gray
+                "9": "5555FF",  // Blue
+                "a": "55FF55",  // Green
+                "b": "55FFFF",  // Aqua
+                "c": "FF5555",  // Red
+                "d": "FF55FF",  // Light Purple
+                "e": "FFFF55",  // Yellow
+                "f": "FFFFFF",  // White
+            };
+            return colorMap[`${char}`]
+        }
+
+        function getDecorationStyleFromChar(char) {
+            const decorationMap = {
+                "k": "font-weight: bold;",
+                "l": "font-weight: bold;",
+                "m": "text-decoration: line-through;",
+                "n": "text-decoration: underline;",
+                "o": "font-style: italic;"
+            }
+            return decorationMap[`${char}`]
+        }
+
+        let coloringMode = false
+        let colorType = ""
+        let coloredText = ""
+
+        let decorationMode = false
+        let decorationStyles = ""
+        let decorationColorType = ""
+
+        let decorationText = ""
+
+        function releaseTextOfColorMode() {
+            if (!coloringMode) return
+            console.log('writing color')
+            htmlText += `<span style="color: #${colorType};">${coloredText}</span>`
+
+            // reset
+            coloringMode = false
+            coloredText = ""
+            colorType = ""
+            console.log('coloring = false')
+        }
+
+        function releaseTextOfDecorationMode() {
+            if (!decorationMode) return
+            console.log('writing decoration')
+            htmlText += `<span style="color: #${decorationColorType}; ${decorationStyles}">${decorationText}</span>`
+
+            // reset
+            decorationMode = false
+            decorationText = ""
+            decorationStyles = ""
+            decorationColorType = ""
+            console.log('decoration = false')
+        }
+
+        for (let i = 0; i < text.length; i++) {
+            const c = text[i]
+            const nextC = text.charAt(i + 1)
+            console.log(`char=${c} at index ${i}`)
+            if (c === "&" && isValidColorChar(nextC)) {
+                // skip to next char
+                i += 1
+
+                // release previous color/decoration
+                releaseTextOfColorMode();
+                releaseTextOfDecorationMode();
+
+                colorType = getColorStyleFromChar(nextC)
+                coloringMode = true
+                console.log('coloring = true')
+                continue
+            } else if (c === "&" && isValidDecorationChar(nextC)) {
+                // skip to next char
+                i += 1
+
+                // release and inherit current decoration style and color
+                if (decorationMode) {
+                    const inheritDecorations = decorationStyles
+                    const inheritDecorationsColor = decorationColorType
+                    releaseTextOfDecorationMode();
+                    decorationStyles += inheritDecorations
+                    decorationColorType = inheritDecorationsColor
+                }
+
+                // inherit current colors
+                if (coloringMode) {
+                    console.log('inheriting colored text to append decoration styles')
+                    decorationColorType = colorType
+                    releaseTextOfColorMode()
+                }
+
+                decorationStyles += getDecorationStyleFromChar(nextC)
+                decorationMode = true
+                console.log('decoration = true')
+                continue
+            } else if (c === "&" && nextC === "r") {
+                // skip to text
+                i += 1
+
+                releaseTextOfColorMode()
+                releaseTextOfDecorationMode()
+                console.log('reset')
+                continue
+            }
+
+            if (coloringMode) {
+                coloredText += c
+            } else if (decorationMode) {
+                decorationText += c
+            } else {
+                htmlText += c
+            }
+        }
+
+        // release leftovers
+        releaseTextOfColorMode()
+        releaseTextOfDecorationMode()
 
         document.getElementById("textinput").focus();
 
-        return getResetStyle() + text;
+        return getResetStyle() + htmlText;
     }
 
     function getResetStyle() {
         if (activeTab === 0 || activeTab === 3 || activeTab === 5 || activeTab === 6 || activeTab === 7) {
-            return `<span style="color: #FFFFFF; ${getResetStyleOptions()}">`;
+            return `<span style="color: #FFFFFF;">`;
         } else if (activeTab === 1 || activeTab === 2) {
-            return `<span style="color: #000000; ${getResetStyleOptions()}">`;
+            return `<span style="color: #000000;">`;
         } else if (activeTab === 4) {
-            return `<span style="color: #AAAAAA; ${getResetStyleOptions()}">`;
+            return `<span style="color: #AAAAAA;">`;
         } else {
-            return `<span style="${getResetStyleOptions()}">`; // Default - No color
+            return `<span>`; // Default - No color
         }
     }
 

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -163,11 +163,11 @@
             const nextC = text.charAt(i + 1)
             let hasFormatSign = c === "&";
 
-            let isGradient = false
+            let gradient = false
             let hexSlice = text.slice(i, i + 8);
-            if (hasFormatSign && (isValidColorChar(nextC) || (isGradient = isGradient(hexSlice)))) {
+            if (hasFormatSign && (isValidColorChar(nextC) || (gradient = isGradient(hexSlice)))) {
                 // skip to next char
-                if (isGradient) {
+                if (gradient) {
                     i += 7
                 } else {
                     i += 1
@@ -177,7 +177,7 @@
                 releaseTextOfColorMode();
                 releaseTextOfDecorationMode();
 
-                if (isGradient) {
+                if (gradient) {
                     colorType = getGradientColor(hexSlice)
                 } else {
                     colorType = getColorStyleFromChar(nextC)

--- a/src/lib/component/util/color-text-generator.svelte
+++ b/src/lib/component/util/color-text-generator.svelte
@@ -125,7 +125,6 @@
         let decorationMode = false
         let decorationStyles = ""
         let decorationColorType = ""
-
         let decorationText = ""
 
         function releaseTextOfColorMode() {
@@ -155,9 +154,12 @@
 
         for (let i = 0; i < text.length; i++) {
             const c = text[i]
-            const nextC = text.charAt(i + 1)
             console.log(`char=${c} at index ${i}`)
-            if (c === "&" && isValidColorChar(nextC)) {
+
+            const nextC = text.charAt(i + 1)
+            let hasFormatSign = c === "&";
+
+            if (hasFormatSign && isValidColorChar(nextC)) {
                 // skip to next char
                 i += 1
 
@@ -169,7 +171,7 @@
                 coloringMode = true
                 console.log('coloring = true')
                 continue
-            } else if (c === "&" && isValidDecorationChar(nextC)) {
+            } else if (hasFormatSign && isValidDecorationChar(nextC)) {
                 // skip to next char
                 i += 1
 
@@ -182,7 +184,7 @@
                     decorationColorType = inheritDecorationsColor
                 }
 
-                // inherit current colors
+                // release and inherit current colors
                 if (coloringMode) {
                     console.log('inheriting colored text to append decoration styles')
                     decorationColorType = colorType
@@ -193,8 +195,8 @@
                 decorationMode = true
                 console.log('decoration = true')
                 continue
-            } else if (c === "&" && nextC === "r") {
-                // skip to text
+            } else if (hasFormatSign && nextC === "r") {
+                // skip to next char
                 i += 1
 
                 releaseTextOfColorMode()


### PR DESCRIPTION
Written from scratch to apply the colors algorithmically. From what I understand, we are not able to reliable remove inherited decorations purely via CSS, as seen in issue https://github.com/flytegg/mc-utils/issues/200. So I went with a systematic approach to eliminate the decorations' inheritance problem once and for all by iterating through each char of given input and handling it appropriately.

Regarding tests, I tested the test cases mentioned in [PR](https://github.com/flytegg/mc-utils/pull/198) with this changes and compared it in-game and I can confirm that everything matches. I also introduced couple more tests below to verify that multi lines and gradient works as expected. 

Since this completely changes how we apply the colors, we need to make sure this works as expected😄

A quick comparison:
- Input: 
&cFirst Test&r
&eSecond
Fourth
  - Current:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/e6442a2c-df10-429a-9da8-4b4959fb9b37) ![image](https://github.com/flytegg/mc-utils/assets/47629321/7db3c45d-1752-4abc-9506-bc59f2021118)

  - Now: 
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/95792204-4582-4433-af8e-0ed326b1c6e0) ![image](https://github.com/flytegg/mc-utils/assets/47629321/8fae1be4-791f-44f4-ba9e-47e0c5aa0736)
    
  - In game:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/cda3d475-c7ff-43ee-8f9f-58dd561fa920)

Test cases (built on top of previous [PR](https://github.com/flytegg/mc-utils/pull/198)):
- Input: &eyellow &lbold &cred &nunderline &rreset &#408080hex
Second line &rreset &9whatever&r
&Third &oitalic &mstrikethrough &rreset
  - Current:
     - ![image](https://github.com/flytegg/mc-utils/assets/47629321/d2a077a5-98cc-42cb-bb18-7b4ae92b2232)
  - Now:
     - ![image](https://github.com/flytegg/mc-utils/assets/47629321/e70cab6b-d833-4e19-b28f-de0a4ef8427e)
  - In game:
    - ![image](https://github.com/flytegg/mc-utils/assets/47629321/87aab048-18b6-4a59-8415-866e15d3b3d5)

