### PR TITLE
Update color codes table to match the new style redesign

### DIFF
--- a/src/lib/component/util/color-codes.svelte
+++ b/src/lib/component/util/color-codes.svelte
@@ -185,13 +185,13 @@ const colors = [
 </script>
 
 <table class="w-[90%] lg:w-[60%] text-white">
-    <tr class="bg-[#1d1f24]">
-        <th class="rounded-tl-lg rounded-bl-lg p-2 pl-6 font-medium text-[20px] text-left">Effect</th>
-        <th class="rounded-tr-lg rounded-br-lg font-medium text-[20px] text-left">Name</th>
-        <th class="rounded-tr-lg rounded-br-lg font-medium text-[20px] text-left">Chat Code</th>
-        <th class="rounded-tr-lg rounded-br-lg font-medium text-[20px] text-left">MiniMessage Tag</th>
-        <th class="rounded-tr-lg rounded-br-lg font-medium text-[20px] text-left">MOTD</th>
-        <th class="rounded-tr-lg rounded-br-lg font-medium text-[20px] text-left">Hex</th>
+    <tr class="text-[#9d9d9e] font-medium">
+        <td class="p-2 pr-4 border-b-[1.5px] border-b-[#232324]">Effect</td>
+        <td class="p-2 pr-4 border-b-[1.5px] border-b-[#232324]">Name</td>
+        <td class="text-left pr-4 border-b-[1.5px] border-b-[#232324]">Chat Code</td>
+        <td class="text-left pr-4 w-[24%] border-b-[1.5px] border-b-[#232324]">MiniMessage Tag</td>
+        <td class="text-left pr-3 w-[15%] border-b-[1.5px] border-b-[#232324]">MOTD</td>
+        <td class="text-left pr-3 w-[15%] border-b-[1.5px] border-b-[#232324]">Hex</td>
     </tr>
     {#each colors as color}
         <tr class="">


### PR DESCRIPTION
During the style redesign, the color codes util got slightly missed out on. This pr hopes to fix that.

This is how it looked like before this fix:
<img width="861" alt="image" src="https://github.com/flytegg/mc-utils/assets/118007877/e51fc02b-e745-440e-b012-d3654155b73b">

And this is after the fix:
<img width="864" alt="image" src="https://github.com/flytegg/mc-utils/assets/118007877/60584298-5279-4ad0-b66a-f4ac567846e3">

Hopefully this matches the new style redesign since I just used the code from other utils. 