### PR TITLE
Fix for earliest vanilla releases showing undefined

### DIFF
--- a/src/lib/component/util/server-jars.svelte
+++ b/src/lib/component/util/server-jars.svelte
@@ -126,13 +126,19 @@
                 <td class="">{selectedType === "fabric" ? 'Not known' : version.release}</td>
                 <td class="justify-end">
                     <div class="flex justify-end items-center h-full pr-1">
-                        <a aria-label='Download Jar' href={version.downloadUrl}>
-                            <button on:click={downloadSuccess}>
-                                <svg class="fill-[#626875] pl-4 h-5" viewBox="0 0 384 512">
-                                    <path d="M32 480c-17.7 0-32-14.3-32-32s14.3-32 32-32H352c17.7 0 32 14.3 32 32s-14.3 32-32 32H32zM214.6 342.6c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 242.7V64c0-17.7 14.3-32 32-32s32 14.3 32 32V242.7l73.4-73.4c12.5-12.5 32.8-12.5 45.3 0s12.5 32.8 0 45.3l-128 128z"/>
-                                </svg>
-                            </button>
-                        </a>
+                        {#if version.downloadUrl}
+                            <a aria-label='Download Jar' href={version.downloadUrl}>
+                                <button on:click={downloadSuccess}>
+                                    <svg class="fill-[#626875] pl-4 h-5" viewBox="0 0 384 512">
+                                        <path d="M32 480c-17.7 0-32-14.3-32-32s14.3-32 32-32H352c17.7 0 32 14.3 32 32s-14.3 32-32 32H32zM214.6 342.6c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 242.7V64c0-17.7 14.3-32 32-32s32 14.3 32 32V242.7l73.4-73.4c12.5-12.5 32.8-12.5 45.3 0s12.5 32.8 0 45.3l-128 128z"/>
+                                    </svg>
+                                </button>
+                            </a>
+                        {:else}
+                            <svg class="fill-[#626875] pl-4 h-5 opacity-30 cursor-not-allowed" viewBox="0 0 384 512">
+                                <path d="M32 480c-17.7 0-32-14.3-32-32s14.3-32 32-32H352c17.7 0 32 14.3 32 32s-14.3 32-32 32H32zM214.6 342.6c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 242.7V64c0-17.7 14.3-32 32-32s32 14.3 32 32V242.7l73.4-73.4c12.5-12.5 32.8-12.5 45.3 0s12.5 32.8 0 45.3l-128 128z"/>
+                            </svg>
+                        {/if}
                     </div>
                 </td>
             </tr>

--- a/src/lib/server-jars/server-jar-utils.ts
+++ b/src/lib/server-jars/server-jar-utils.ts
@@ -167,7 +167,7 @@ export const fetchVanillaDetailsFor = async (version: string) => {
         display: "Vanilla",
         version: version,
         release: formatDate(new Date(response.releaseTime)),
-        downloadUrl: details.downloads.server.url
+        downloadUrl: details.downloads.server?.url
     }
 }
 

--- a/src/routes/api/server-jars/[platform]/[version]/+server.ts
+++ b/src/routes/api/server-jars/[platform]/[version]/+server.ts
@@ -3,6 +3,8 @@ import type { RequestHandler } from "./$types";
 import { fetchDetailsFor } from "$lib/server-jars/server-jar-utils";
 import { corsMiddleware } from "$lib/cors";
 
+const VANILLA_PROBLEMATIC_VERSIONS = new Set(['1.0', '1.1', '1.2.1', '1.2.2', '1.2.3', '1.2.4']);
+
 export const GET: RequestHandler = corsMiddleware(async ({ params, url }) => {
   if (!params.platform || !params.version) {
     throw error(400, {
@@ -17,12 +19,23 @@ export const GET: RequestHandler = corsMiddleware(async ({ params, url }) => {
     throw error(404, {
       message: `Unknown platform or version: ${params.platform}, ${params.version}`,
     });
-  return json({
+
+  const responseData = {
     platform: response.platform,
     display: response.display,
     version: response.version,
     release: response.release,
+  };
+  if (params.platform === 'vanilla' && VANILLA_PROBLEMATIC_VERSIONS.has(params.version)) {
+    return json({
+      ...responseData,
+      size: undefined,
+      downloadUrl: undefined
+    });
+  }
+  return json({
+    ...responseData,
     size: response.size,
-    downloadUrl: `${url.href}/download`,
+    downloadUrl: `${url.href}/download`
   });
 });


### PR DESCRIPTION
Definitely needs to be rewritten but seems like a nice temporary fix until someone who actually understands the server-jar api can fix it properly :) 

Fixes #214

Before:
![image](https://github.com/user-attachments/assets/89adf599-1776-4afe-a181-6e0ad9a76bd2)
After:
![image](https://github.com/user-attachments/assets/c1e22d92-78d1-4504-8cce-65377f0cfe7e)

PS: download buttons do have cursor-not-allowed and opacity-30 to show they cannot be downloaded